### PR TITLE
Refactor/drawing canvas

### DIFF
--- a/frontend/src/test/DrawingCanvas.test.tsx
+++ b/frontend/src/test/DrawingCanvas.test.tsx
@@ -9,6 +9,7 @@ import '@testing-library/jest-dom' // ToBeIndocument()등의 메소드를 쓰려
 import * as sketchHook from '../hooks/sketch'
 import configureStore from 'redux-mock-store'
 import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
 const mockStore = configureStore([])
 describe('DrawingCanvas', () => {
   let store: ReturnType<typeof mockStore>
@@ -40,9 +41,11 @@ describe('DrawingCanvas', () => {
     // useCreateSketch 훅을 모킹
 
     render(
-      <Provider store={store}>
-        <DrawingCanvas />
-      </Provider>
+      <MemoryRouter>
+        <Provider store={store}>
+          <DrawingCanvas />
+        </Provider>
+      </MemoryRouter>
     )
     expect(screen.getByTestId('status')).toHaveTextContent('idle')
   })
@@ -65,9 +68,11 @@ describe('DrawingCanvas', () => {
       uploadedImageUrl: successImage
     })
     render(
-      <Provider store={store}>
-        <DrawingCanvas />
-      </Provider>
+      <MemoryRouter>
+        <Provider store={store}>
+          <DrawingCanvas />
+        </Provider>
+      </MemoryRouter>
     )
     //상태 잘 넘어오는지 확인
     expect(screen.getByTestId('status')).toHaveTextContent('success')


### PR DESCRIPTION
1. canvas(그림판 객체), ctx(그리기 도구 객체) 생성 로직 리팩토링

이슈내용
- 매 함수 호출 시마다 canvas와 ctx를 매번 생성하여 메모리 과 점유 및 비효율 발생

해결
- useEffect훅을 사용하여 앱이 처음 로드 될때만 canvas와 ctx를 생성하고, 실제 접근은 getter로 할 수 있도록 수정
* useEffect 훅 : 앱이 처음 실행되고 Dom이 로드되고 최초 1회만 실행 -> 중복객체 생성 방지

2. TC수정
- SearchDialog 컴포넌트 도입으로 인한 Router로 전체를 감싸야 컴포넌트가 정상동작함